### PR TITLE
Allow not writing default values for constraints

### DIFF
--- a/AGXUnity/BrickUnity/BrickPrefabImporter.cs
+++ b/AGXUnity/BrickUnity/BrickPrefabImporter.cs
@@ -212,8 +212,8 @@ namespace AGXUnity.BrickUnity
       c_attachmentPair.ConnectedObject = b_body2 is null ? null : bodyDict[b_body2 as B_RigidBody];
       c_attachmentPair.ConnectedFrame = new AGXUnity.ConstraintFrame(attachmentDict[b_attachment2]);
 
-      constraint.SetComplianceAndDamping(b_connector.MainInteraction);
-      constraint.SetControllers(b_connector);
+      constraint.SetComplianceAndDamping(b_connector.MainInteraction, overwriteIfDefault: true);
+      constraint.SetControllers(b_connector, overwriteIfDefault: true);
 
       return go_constraint;
     }

--- a/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
+++ b/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
@@ -3,28 +3,38 @@
 using B_Connector = Brick.Physics.Mechanics.AttachmentPairConnector;
 using B_Interaction = Brick.Physics.Mechanics.AttachmentPairInteraction;
 using B_Mechanics = Brick.Physics.Mechanics;
+using B_Stiffness = Brick.Physics.Mechanics.InteractionData6D.Stiffness6D;
+using B_Damping = Brick.Physics.Mechanics.InteractionData6D.Damping6D;
+
+using AU_Constraint = AGXUnity.Constraint;
+using AU_Controller = AGXUnity.ElementaryConstraintController;
+using AU_LockController = AGXUnity.LockController;
+using AU_MotorController = AGXUnity.TargetSpeedController;
+using AU_RangeController = AGXUnity.RangeController;
+using AU_FrictionController = AGXUnity.FrictionController;
+using AU_ControllerType = AGXUnity.Constraint.ControllerType;
 
 namespace AGXUnity.BrickUnity.Factories
 {
   public static class ConstraintFactory
   {
-    public static void SetControllers(this AGXUnity.Constraint constraint, B_Connector b_connector)
+    public static void SetControllers(this AU_Constraint constraint, B_Connector b_connector, bool overwriteIfDefault)
     {
       foreach (var b_interaction in b_connector.Interactions)
       {
         switch (b_interaction)
         {
           case B_Interaction.MotorInteraction1D b_motor1D:
-            constraint.SetTargetSpeedController(b_motor1D);
+            constraint.SetTargetSpeedController(b_motor1D, overwriteIfDefault);
             break;
           case B_Interaction.LockInteraction1D b_lock1D:
-            constraint.SetLockController(b_lock1D);
+            constraint.SetLockController(b_lock1D, overwriteIfDefault);
             break;
           case B_Interaction.RangeMinMaxInteraction1D b_range1D:
-            constraint.SetRangeController(b_range1D);
+            constraint.SetRangeController(b_range1D, overwriteIfDefault);
             break;
           case B_Interaction.FrictionInteraction1D b_friction1D:
-            constraint.SetFrictionController(b_friction1D);
+            constraint.SetFrictionController(b_friction1D, overwriteIfDefault);
             break;
           default:
             if (b_interaction != b_connector.MainInteraction)
@@ -37,125 +47,245 @@ namespace AGXUnity.BrickUnity.Factories
       }
     }
 
-    public static void SetTargetSpeedController(this AGXUnity.Constraint constraint, B_Interaction.MotorInteraction1D b_motor1D)
+    public static void SetTargetSpeedController(this AU_Constraint constraint,
+                                                B_Interaction.MotorInteraction1D b_motor1D,
+                                                bool overwriteIfDefault)
     {
-      var controllerType = AGXUnity.Constraint.ControllerType.Primary;
+      var controllerType = AU_ControllerType.Primary;
       if (b_motor1D is B_Interaction.RotationalMotorInteraction1D)
-        controllerType = AGXUnity.Constraint.ControllerType.Rotational;
+        controllerType = AU_ControllerType.Rotational;
       else if (b_motor1D is B_Interaction.TranslationalMotorInteraction1D)
-        controllerType = AGXUnity.Constraint.ControllerType.Translational;
+        controllerType = AU_ControllerType.Translational;
 
-      var targetSpeedController = constraint.GetController<AGXUnity.TargetSpeedController>(controllerType);
+      var targetSpeedController = constraint.GetController<AU_MotorController>(controllerType);
 
-      targetSpeedController.SetGeneralControllerValues(b_motor1D);
-      targetSpeedController.Speed = (float)b_motor1D.Speed;
-      targetSpeedController.LockAtZeroSpeed = b_motor1D.LockAtZeroSpeed;
+      targetSpeedController.SetGeneralControllerValues(b_motor1D, overwriteIfDefault);
+      if (overwriteIfDefault || !b_motor1D._speedIsDefault)
+        targetSpeedController.Speed = (float)b_motor1D.Speed;
+      if (overwriteIfDefault || !b_motor1D._lockAtZeroSpeedIsDefault)
+        targetSpeedController.LockAtZeroSpeed = b_motor1D.LockAtZeroSpeed;
     }
 
-    public static void SetLockController(this AGXUnity.Constraint constraint, B_Interaction.LockInteraction1D b_lock1D)
+    public static void SetLockController(this AU_Constraint constraint,
+                                         B_Interaction.LockInteraction1D b_lock1D,
+                                         bool overwriteIfDefault)
     {
-      var controllerType = AGXUnity.Constraint.ControllerType.Primary;
+      var controllerType = AU_ControllerType.Primary;
       if (b_lock1D is B_Interaction.TranslationalLockInteraction1D)
-        controllerType = AGXUnity.Constraint.ControllerType.Translational;
+        controllerType = AU_ControllerType.Translational;
       // No RotationalLockInteraction1D existing in brick....
-      var lockController = constraint.GetController<AGXUnity.LockController>(controllerType);
-      lockController.SetGeneralControllerValues(b_lock1D);
+      var lockController = constraint.GetController<AU_LockController>(controllerType);
+      lockController.SetGeneralControllerValues(b_lock1D, overwriteIfDefault);
       //lockController.Position = ??
     }
 
-    public static void SetRangeController(this AGXUnity.Constraint constraint, B_Interaction.RangeMinMaxInteraction1D b_range1D)
+    public static void SetRangeController(this AU_Constraint constraint,
+                                          B_Interaction.RangeMinMaxInteraction1D b_range1D,
+                                          bool overwriteIfDefault)
     {
-      var controllerType = AGXUnity.Constraint.ControllerType.Primary;
+      var controllerType = AU_ControllerType.Primary;
       if (b_range1D is B_Interaction.RotationalRangeMinMaxInteraction1D)
-        controllerType = AGXUnity.Constraint.ControllerType.Rotational;
+        controllerType = AU_ControllerType.Rotational;
       else if (b_range1D is B_Interaction.TranslationalRangeMinMaxInteraction1D)
-        controllerType = AGXUnity.Constraint.ControllerType.Translational;
+        controllerType = AU_ControllerType.Translational;
 
-      var rangeController = constraint.GetController<AGXUnity.RangeController>(controllerType);
+      var rangeController = constraint.GetController<AU_RangeController>(controllerType);
 
-      rangeController.SetGeneralControllerValues(b_range1D);
-      float minValue = (float)Brick.Math.Utils.ToRad(b_range1D.MinValue);
-      float maxValue = (float)Brick.Math.Utils.ToRad(b_range1D.MaxValue);
-      rangeController.Range = new AGXUnity.RangeReal(minValue, maxValue);
+      rangeController.SetGeneralControllerValues(b_range1D, overwriteIfDefault);
+      var range = rangeController.Range;
+      if (overwriteIfDefault || !b_range1D._minValueIsDefault)
+        range.Min = (float)Brick.Math.Utils.ToRad(b_range1D.MinValue);
+      if (overwriteIfDefault || !b_range1D._maxValueIsDefault)
+        range.Max = (float)Brick.Math.Utils.ToRad(b_range1D.MaxValue);
+      rangeController.Range = range;
     }
 
-    public static void SetFrictionController(this AGXUnity.Constraint constraint, B_Interaction.FrictionInteraction1D b_friction1D)
+    public static void SetFrictionController(this AU_Constraint constraint,
+                                             B_Interaction.FrictionInteraction1D b_friction1D,
+                                             bool overwriteIfDefault)
     {
-      var controllerType = AGXUnity.Constraint.ControllerType.Primary;
+      var controllerType = AU_ControllerType.Primary;
       if (b_friction1D is B_Interaction.RotationalFrictionInteraction1D)
-        controllerType = AGXUnity.Constraint.ControllerType.Rotational;
+        controllerType = AU_ControllerType.Rotational;
       else if (b_friction1D is B_Interaction.TranslationalFrictionInteraction1D)
-        controllerType = AGXUnity.Constraint.ControllerType.Translational;
+        controllerType = AU_ControllerType.Translational;
 
-      var frictionController = constraint.GetController<AGXUnity.FrictionController>(controllerType);
+      var frictionController = constraint.GetController<AU_FrictionController>(controllerType);
 
-      frictionController.SetGeneralControllerValues(b_friction1D);
-      frictionController.FrictionCoefficient = (float)b_friction1D.Coefficient;
+      frictionController.SetGeneralControllerValues(b_friction1D, overwriteIfDefault);
+      if (overwriteIfDefault || !b_friction1D._coefficientIsDefault)
+        frictionController.FrictionCoefficient = (float)b_friction1D.Coefficient;
     }
 
-    public static void SetGeneralControllerValues(this AGXUnity.ElementaryConstraintController controller, B_Interaction.Interaction1D b_interaction)
+    public static void SetGeneralControllerValues(this AU_Controller controller,
+                                                  B_Interaction.Interaction1D b_interaction,
+                                                  bool overwriteIfDefault)
     {
-      controller.Enable = b_interaction.Enabled;
-      controller.Compliance = 1f / (float)b_interaction.Stiffness;
-      controller.Damping = (float)b_interaction.Damping / (float)b_interaction.Stiffness;
-      controller.ForceRange = new AGXUnity.RangeReal((float)b_interaction.MinForce, (float)b_interaction.MaxForce);
+      if (overwriteIfDefault || !b_interaction._enabledIsDefault)
+        controller.Enable = b_interaction.Enabled;
+      if (overwriteIfDefault || !b_interaction._stiffnessIsDefault)
+        controller.Compliance = 1f / (float)b_interaction.Stiffness;
+      if (overwriteIfDefault || !b_interaction._dampingIsDefault)
+        controller.Damping = (float)b_interaction.Damping * controller.Compliance;
+      var forceRange = controller.ForceRange;
+      if (overwriteIfDefault || !b_interaction._minForceIsDefault)
+        forceRange.Min = (float)b_interaction.MinForce;
+      if (overwriteIfDefault || !b_interaction._maxForceIsDefault)
+        forceRange.Max = (float)b_interaction.MaxForce;
+      controller.ForceRange = forceRange;
     }
 
-
-    public static void SetBallJointComplianceAndDamping(this AGXUnity.Constraint constraint, B_Interaction b_interaction)
+    public static void SetBallJointComplianceAndDamping(this AU_Constraint constraint,
+                                                        B_Interaction b_interaction,
+                                                        bool overwriteIfDefault)
     {
-      constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AlongNormal, AGXUnity.Constraint.TranslationalDof.X);
-      constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AlongCross, AGXUnity.Constraint.TranslationalDof.Y);
-      constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AlongTangent, AGXUnity.Constraint.TranslationalDof.Z);
-
-      constraint.SetDamping((float)(b_interaction.Damping6D.AlongNormal / b_interaction.Stiffness6D.AlongNormal),
-                            AGXUnity.Constraint.TranslationalDof.X);
-      constraint.SetDamping((float)(b_interaction.Damping6D.AlongCross / b_interaction.Stiffness6D.AlongCross),
-                            AGXUnity.Constraint.TranslationalDof.Y);
-      constraint.SetDamping((float)(b_interaction.Damping6D.AlongTangent / b_interaction.Stiffness6D.AlongTangent),
-                            AGXUnity.Constraint.TranslationalDof.Z);
+      constraint.SetBrickCompliance(b_interaction.Stiffness6D, AU_Constraint.TranslationalDof.X, overwriteIfDefault);
+      constraint.SetBrickCompliance(b_interaction.Stiffness6D, AU_Constraint.TranslationalDof.Y, overwriteIfDefault);
+      constraint.SetBrickCompliance(b_interaction.Stiffness6D, AU_Constraint.TranslationalDof.Z, overwriteIfDefault);
+      constraint.SetBrickDamping(b_interaction.Damping6D, AU_Constraint.TranslationalDof.X, overwriteIfDefault);
+      constraint.SetBrickDamping(b_interaction.Damping6D, AU_Constraint.TranslationalDof.Y, overwriteIfDefault);
+      constraint.SetBrickDamping(b_interaction.Damping6D, AU_Constraint.TranslationalDof.Z, overwriteIfDefault);
     }
 
-    public static void SetComplianceAndDamping(this AGXUnity.Constraint constraint, B_Interaction b_interaction)
+    public static float GetValue(this B_Mechanics.InteractionData6D data, AU_Constraint.RotationalDof dof)
     {
-      if (b_interaction is B_Mechanics.LockJointInteraction ||
-        b_interaction is B_Mechanics.HingeInteraction ||
-        b_interaction is B_Mechanics.PrismaticInteraction ||
-        b_interaction is B_Mechanics.CylindricalInteraction)
+      switch (dof)
       {
-        constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AlongNormal, AGXUnity.Constraint.TranslationalDof.X);
-        constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AlongCross, AGXUnity.Constraint.TranslationalDof.Y);
-        if (b_interaction is B_Mechanics.LockJointInteraction || b_interaction is B_Mechanics.HingeInteraction)
-          constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AlongTangent, AGXUnity.Constraint.TranslationalDof.Z);
+        case AU_Constraint.RotationalDof.X:
+          return (float)data.AroundNormal;
+        case AU_Constraint.RotationalDof.Y:
+          return (float)data.AroundCross;
+        case AU_Constraint.RotationalDof.Z:
+          return (float)data.AroundTangent;
+        default:
+          throw new System.ArgumentException($"Cannot get interaction data value for degree of freedom \"{dof}\". Select either X, Y or Z");
+      }
+    }
 
-        constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AroundNormal, AGXUnity.Constraint.RotationalDof.X);
-        constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AroundCross, AGXUnity.Constraint.RotationalDof.Y);
-        if (b_interaction is B_Mechanics.LockJointInteraction || b_interaction is B_Mechanics.PrismaticInteraction)
-          constraint.SetCompliance(1f / (float)b_interaction.Stiffness6D.AroundTangent, AGXUnity.Constraint.RotationalDof.Z);
+    public static float GetValue(this B_Mechanics.InteractionData6D data, AU_Constraint.TranslationalDof dof)
+    {
+      switch (dof)
+      {
+        case AU_Constraint.TranslationalDof.X:
+          return (float)data.AlongNormal;
+        case AU_Constraint.TranslationalDof.Y:
+          return (float)data.AlongCross;
+        case AU_Constraint.TranslationalDof.Z:
+          return (float)data.AlongTangent;
+        default:
+          throw new System.ArgumentException($"Cannot get interaction data value for degree of freedom \"{dof}\". Select either X, Y or Z");
+      }
+    }
 
-        constraint.SetDamping((float)(b_interaction.Damping6D.AlongNormal / b_interaction.Stiffness6D.AlongNormal),
-                              AGXUnity.Constraint.TranslationalDof.X);
-        constraint.SetDamping((float)(b_interaction.Damping6D.AlongCross / b_interaction.Stiffness6D.AlongCross),
-                              AGXUnity.Constraint.TranslationalDof.Y);
-        if (b_interaction is B_Mechanics.LockJointInteraction || b_interaction is B_Mechanics.HingeInteraction)
-          constraint.SetDamping((float)(b_interaction.Damping6D.AlongTangent / b_interaction.Stiffness6D.AlongTangent),
-                                AGXUnity.Constraint.TranslationalDof.Z);
+    public static bool GetValueIsDefault(this B_Mechanics.InteractionData6D data, AU_Constraint.RotationalDof dof)
+    {
+      switch (dof)
+      {
+        case AU_Constraint.RotationalDof.X:
+          return data._aroundNormalIsDefault;
+        case AU_Constraint.RotationalDof.Y:
+          return data._aroundCrossIsDefault;
+        case AU_Constraint.RotationalDof.Z:
+          return data._aroundTangentIsDefault;
+        default:
+          return data._aroundNormalIsDefault && data._aroundCrossIsDefault && data._aroundTangentIsDefault;
+      }
+    }
 
-        constraint.SetDamping((float)(b_interaction.Damping6D.AroundNormal / b_interaction.Stiffness6D.AroundNormal),
-                              AGXUnity.Constraint.RotationalDof.X);
-        constraint.SetDamping((float)(b_interaction.Damping6D.AroundCross / b_interaction.Stiffness6D.AroundCross),
-                              AGXUnity.Constraint.RotationalDof.Y);
-        if (b_interaction is B_Mechanics.LockJointInteraction || b_interaction is B_Mechanics.PrismaticInteraction)
-          constraint.SetDamping((float)(b_interaction.Damping6D.AroundTangent / b_interaction.Stiffness6D.AroundTangent),
-                                AGXUnity.Constraint.RotationalDof.Z);
+    public static bool GetValueIsDefault(this B_Mechanics.InteractionData6D data, AU_Constraint.TranslationalDof dof)
+    {
+      switch (dof)
+      {
+        case AU_Constraint.TranslationalDof.X:
+          return data._alongNormalIsDefault;
+        case AU_Constraint.TranslationalDof.Y:
+          return data._alongCrossIsDefault;
+        case AU_Constraint.TranslationalDof.Z:
+          return data._alongTangentIsDefault;
+        default:
+          return data._alongNormalIsDefault && data._alongCrossIsDefault && data._alongTangentIsDefault;
+      }
+    }
+
+    public static void SetBrickDamping(this AU_Constraint constraint,
+                                       B_Damping damping,
+                                       AU_Constraint.RotationalDof dof,
+                                       bool overwriteIfDefault)
+    {
+      if (overwriteIfDefault || !damping.GetValueIsDefault(dof))
+        constraint.SetDamping(damping.GetValue(dof) * constraint.GetDamping(dof), dof);
+    }
+
+    public static void SetBrickDamping(this AU_Constraint constraint,
+                                       B_Damping damping,
+                                       AU_Constraint.TranslationalDof dof,
+                                       bool overwriteIfDefault)
+    {
+      if (overwriteIfDefault || !damping.GetValueIsDefault(dof))
+        constraint.SetDamping(damping.GetValue(dof) * constraint.GetDamping(dof), dof);
+    }
+
+    public static void SetBrickCompliance(this AU_Constraint constraint,
+                                          B_Stiffness stiffness,
+                                          AU_Constraint.RotationalDof dof,
+                                          bool overwriteIfDefault)
+    {
+      if (overwriteIfDefault || !stiffness.GetValueIsDefault(dof))
+        constraint.SetCompliance(1f / stiffness.GetValue(dof), dof);
+    }
+
+    public static void SetBrickCompliance(this AU_Constraint constraint,
+                                          B_Stiffness stiffness,
+                                          AU_Constraint.TranslationalDof dof,
+                                          bool overwriteIfDefault)
+    {
+      if (overwriteIfDefault || !stiffness.GetValueIsDefault(dof))
+        constraint.SetCompliance(1f / stiffness.GetValue(dof), dof);
+    }
+
+    public static void SetComplianceAndDamping(this AU_Constraint constraint,
+                                               B_Interaction b_interaction,
+                                               bool overwriteIfDefault)
+    {
+      var damping6D = b_interaction.Damping6D;
+      var stiffness6D = b_interaction.Stiffness6D;
+      if (b_interaction is B_Mechanics.LockJointInteraction ||
+          b_interaction is B_Mechanics.HingeInteraction ||
+          b_interaction is B_Mechanics.PrismaticInteraction ||
+          b_interaction is B_Mechanics.CylindricalInteraction)
+      {
+        bool isLockOrHinge = b_interaction is B_Mechanics.LockJointInteraction ||
+                             b_interaction is B_Mechanics.HingeInteraction;
+        bool isLockOrPrismatic = b_interaction is B_Mechanics.LockJointInteraction ||
+                                 b_interaction is B_Mechanics.PrismaticInteraction;
+
+        constraint.SetBrickCompliance(stiffness6D, AU_Constraint.TranslationalDof.X, overwriteIfDefault);
+        constraint.SetBrickCompliance(stiffness6D, AU_Constraint.TranslationalDof.Y, overwriteIfDefault);
+        if (isLockOrHinge)
+          constraint.SetBrickCompliance(stiffness6D, AU_Constraint.TranslationalDof.Z, overwriteIfDefault);
+
+        constraint.SetBrickCompliance(stiffness6D, AU_Constraint.RotationalDof.X, overwriteIfDefault);
+        constraint.SetBrickCompliance(stiffness6D, AU_Constraint.RotationalDof.Y, overwriteIfDefault);
+        if (isLockOrPrismatic)
+          constraint.SetBrickCompliance(stiffness6D, AU_Constraint.RotationalDof.Z, overwriteIfDefault);
+
+        constraint.SetBrickDamping(damping6D, AU_Constraint.TranslationalDof.X, overwriteIfDefault);
+        constraint.SetBrickDamping(damping6D, AU_Constraint.TranslationalDof.Y, overwriteIfDefault);
+        if (isLockOrHinge)
+          constraint.SetBrickDamping(damping6D, AU_Constraint.TranslationalDof.Z, overwriteIfDefault);
+
+        constraint.SetBrickDamping(damping6D, AU_Constraint.RotationalDof.X, overwriteIfDefault);
+        constraint.SetBrickDamping(damping6D, AU_Constraint.RotationalDof.Y, overwriteIfDefault);
+        if (isLockOrPrismatic)
+          constraint.SetBrickDamping(damping6D, AU_Constraint.RotationalDof.Z, overwriteIfDefault);
       }
       else if (b_interaction is B_Mechanics.BallJointInteraction)
-        constraint.SetBallJointComplianceAndDamping(b_interaction);
+        constraint.SetBallJointComplianceAndDamping(b_interaction, overwriteIfDefault);
       else if (b_interaction is B_Mechanics.SpringJointInteraction)
       {
-        var lockController = constraint.GetController<AGXUnity.LockController>();
-        lockController.Compliance = 1f / (float)b_interaction.Stiffness6D.AlongTangent;
-        lockController.Damping = (float)(b_interaction.Damping6D.AlongTangent / b_interaction.Stiffness6D.AlongTangent);
+        var lockController = constraint.GetController<AU_LockController>();
+        lockController.Compliance = 1f / (float)stiffness6D.AlongTangent;
+        lockController.Damping = (float)(damping6D.AlongTangent / stiffness6D.AlongTangent);
       }
     }
   }

--- a/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
+++ b/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
@@ -47,6 +47,12 @@ namespace AGXUnity.BrickUnity.Factories
       }
     }
 
+    /// <summary>
+    /// Set the properties of the target speed controller of a constraint from a Brick object
+    /// </summary>
+    /// <param name="constraint">An AGXUnity.Constraint with a target speed controller</param>
+    /// <param name="b_motor1D">A Brick motor 1D interaction</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetTargetSpeedController(this AU_Constraint constraint,
                                                 B_Interaction.MotorInteraction1D b_motor1D,
                                                 bool overwriteIfDefault)
@@ -66,6 +72,12 @@ namespace AGXUnity.BrickUnity.Factories
         targetSpeedController.LockAtZeroSpeed = b_motor1D.LockAtZeroSpeed;
     }
 
+    /// <summary>
+    /// Set the properties of the lock controller of a constraint from a Brick object
+    /// </summary>
+    /// <param name="constraint">An AGXUnity.Constraint with a lock controller</param>
+    /// <param name="b_lock1D">A Brick lock 1D interaction</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetLockController(this AU_Constraint constraint,
                                          B_Interaction.LockInteraction1D b_lock1D,
                                          bool overwriteIfDefault)
@@ -79,6 +91,12 @@ namespace AGXUnity.BrickUnity.Factories
       //lockController.Position = ??
     }
 
+    /// <summary>
+    /// Set the properties of the range controller of a constraint from a Brick object
+    /// </summary>
+    /// <param name="constraint">An AGXUnity.Constraint with a range controller</param>
+    /// <param name="b_range1D">A Brick range 1D interaction</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetRangeController(this AU_Constraint constraint,
                                           B_Interaction.RangeMinMaxInteraction1D b_range1D,
                                           bool overwriteIfDefault)
@@ -100,6 +118,12 @@ namespace AGXUnity.BrickUnity.Factories
       rangeController.Range = range;
     }
 
+    /// <summary>
+    /// Set the properties of the friction controller of a constraint from a Brick object
+    /// </summary>
+    /// <param name="constraint">An AGXUnity.Constraint with a friction controller</param>
+    /// <param name="b_friction1D">A Brick friction 1D interaction</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetFrictionController(this AU_Constraint constraint,
                                              B_Interaction.FrictionInteraction1D b_friction1D,
                                              bool overwriteIfDefault)
@@ -117,6 +141,12 @@ namespace AGXUnity.BrickUnity.Factories
         frictionController.FrictionCoefficient = (float)b_friction1D.Coefficient;
     }
 
+    /// <summary>
+    /// Set compliance, damping and force range of a controller.
+    /// </summary>
+    /// <param name="controller">An AGXUnity 1D controller on which to set the properties</param>
+    /// <param name="b_interaction">A Brick 1D interaction from which the properties will be set</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity controller's values even if the Brick values are default</param>
     public static void SetGeneralControllerValues(this AU_Controller controller,
                                                   B_Interaction.Interaction1D b_interaction,
                                                   bool overwriteIfDefault)
@@ -135,6 +165,12 @@ namespace AGXUnity.BrickUnity.Factories
       controller.ForceRange = forceRange;
     }
 
+    /// <summary>
+    /// Set compliance and damping on all degrees of freedom of a ball joint
+    /// </summary>
+    /// <param name="constraint">The AGXUnity ball joint constraint on which to set the values</param>
+    /// <param name="b_interaction">The Brick interaction from which the values will be set</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity controller's values even if the Brick values are default</param>
     public static void SetBallJointComplianceAndDamping(this AU_Constraint constraint,
                                                         B_Interaction b_interaction,
                                                         bool overwriteIfDefault)
@@ -147,6 +183,12 @@ namespace AGXUnity.BrickUnity.Factories
       constraint.SetBrickDamping(b_interaction.Damping6D, AU_Constraint.TranslationalDof.Z, overwriteIfDefault);
     }
 
+    /// <summary>
+    ///Get a value from a Brick interaction data (compliance or damping) given a rotational degree of freedom
+    /// </summary>
+    /// <param name="data">The Brick interaction data</param>
+    /// <param name="dof">The degree of freedom for which to get the value</param>
+    /// <returns>The interaction value (compliance or damping)</returns>
     public static float GetValue(this B_Mechanics.InteractionData6D data, AU_Constraint.RotationalDof dof)
     {
       switch (dof)
@@ -162,6 +204,12 @@ namespace AGXUnity.BrickUnity.Factories
       }
     }
 
+    /// <summary>
+    ///Get a value from a Brick interaction data (compliance or damping) given a translational degree of freedom
+    /// </summary>
+    /// <param name="data">The Brick interaction data</param>
+    /// <param name="dof">The degree of freedom for which to get the value</param>
+    /// <returns>The interaction value (compliance or damping)</returns>
     public static float GetValue(this B_Mechanics.InteractionData6D data, AU_Constraint.TranslationalDof dof)
     {
       switch (dof)
@@ -177,6 +225,12 @@ namespace AGXUnity.BrickUnity.Factories
       }
     }
 
+    /// <summary>
+    /// Check if a Brick interaction data value (compliance or damping) is default (not manually set by the user)
+    /// </summary>
+    /// <param name="data">The Brick interaction data</param>
+    /// <param name="dof">The degree of freedom for which to check</param>
+    /// <returns>True if the interaction data value is default</returns>
     public static bool GetValueIsDefault(this B_Mechanics.InteractionData6D data, AU_Constraint.RotationalDof dof)
     {
       switch (dof)
@@ -192,6 +246,12 @@ namespace AGXUnity.BrickUnity.Factories
       }
     }
 
+    /// <summary>
+    /// Check if a Brick interaction data value (compliance or damping) is default (not manually set by the user)
+    /// </summary>
+    /// <param name="data">The Brick interaction data</param>
+    /// <param name="dof">The degree of freedom for which to check</param>
+    /// <returns>True if the interaction data value is default</returns>
     public static bool GetValueIsDefault(this B_Mechanics.InteractionData6D data, AU_Constraint.TranslationalDof dof)
     {
       switch (dof)
@@ -207,6 +267,13 @@ namespace AGXUnity.BrickUnity.Factories
       }
     }
 
+    /// <summary>
+    /// Set damping of an AGXUnity constraint from Brick, for a specific degree of freedom
+    /// </summary>
+    /// <param name="constraint">The AGXUnity constraint on which to set the damping</param>
+    /// <param name="damping">The Brick damping to set</param>
+    /// <param name="dof">The degree of freedom for which to set the damping</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetBrickDamping(this AU_Constraint constraint,
                                        B_Damping damping,
                                        AU_Constraint.RotationalDof dof,
@@ -216,6 +283,13 @@ namespace AGXUnity.BrickUnity.Factories
         constraint.SetDamping(damping.GetValue(dof) * constraint.GetDamping(dof), dof);
     }
 
+    /// <summary>
+    /// Set damping of an AGXUnity constraint from Brick, for a specific degree of freedom
+    /// </summary>
+    /// <param name="constraint">The AGXUnity constraint on which to set the damping</param>
+    /// <param name="damping">The Brick damping to set</param>
+    /// <param name="dof">The degree of freedom for which to set the damping</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetBrickDamping(this AU_Constraint constraint,
                                        B_Damping damping,
                                        AU_Constraint.TranslationalDof dof,
@@ -225,6 +299,13 @@ namespace AGXUnity.BrickUnity.Factories
         constraint.SetDamping(damping.GetValue(dof) * constraint.GetDamping(dof), dof);
     }
 
+    /// <summary>
+    /// Set compliance of an AGXUnity constraint from Brick stiffness, for a specific degree of freedom
+    /// </summary>
+    /// <param name="constraint">The AGXUnity constraint on which to set the compliance</param>
+    /// <param name="stiffness">The Brick stiffness to set</param>
+    /// <param name="dof">The degree of freedom for which to set the compliance</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetBrickCompliance(this AU_Constraint constraint,
                                           B_Stiffness stiffness,
                                           AU_Constraint.RotationalDof dof,
@@ -234,6 +315,13 @@ namespace AGXUnity.BrickUnity.Factories
         constraint.SetCompliance(1f / stiffness.GetValue(dof), dof);
     }
 
+    /// <summary>
+    /// Set compliance of an AGXUnity constraint from Brick stiffness, for a specific degree of freedom
+    /// </summary>
+    /// <param name="constraint">The AGXUnity constraint on which to set the compliance</param>
+    /// <param name="stiffness">The Brick stiffness to set</param>
+    /// <param name="dof">The degree of freedom for which to set the compliance</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetBrickCompliance(this AU_Constraint constraint,
                                           B_Stiffness stiffness,
                                           AU_Constraint.TranslationalDof dof,
@@ -243,6 +331,12 @@ namespace AGXUnity.BrickUnity.Factories
         constraint.SetCompliance(1f / stiffness.GetValue(dof), dof);
     }
 
+    /// <summary>
+    /// Set compliance and damping of an AGXUnity constraint given a Brick interaction
+    /// </summary>
+    /// <param name="constraint">The AGXUnity constraint on which to set the compliance and damping</param>
+    /// <param name="b_interaction">The Brick interaction from which the values will be set</param>
+    /// <param name="overwriteIfDefault">Set to true to overwrite the AGXUnity constraint's values even if the Brick values are default</param>
     public static void SetComplianceAndDamping(this AU_Constraint constraint,
                                                B_Interaction b_interaction,
                                                bool overwriteIfDefault)

--- a/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
+++ b/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
@@ -280,7 +280,7 @@ namespace AGXUnity.BrickUnity.Factories
                                        bool overwriteIfDefault)
     {
       if (overwriteIfDefault || !damping.GetValueIsDefault(dof))
-        constraint.SetDamping(damping.GetValue(dof) * constraint.GetDamping(dof), dof);
+        constraint.SetDamping(damping.GetValue(dof) * constraint.GetCompliance(dof), dof);
     }
 
     /// <summary>
@@ -296,7 +296,7 @@ namespace AGXUnity.BrickUnity.Factories
                                        bool overwriteIfDefault)
     {
       if (overwriteIfDefault || !damping.GetValueIsDefault(dof))
-        constraint.SetDamping(damping.GetValue(dof) * constraint.GetDamping(dof), dof);
+        constraint.SetDamping(damping.GetValue(dof) * constraint.GetCompliance(dof), dof);
     }
 
     /// <summary>

--- a/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
+++ b/AGXUnity/BrickUnity/Factories/ConstraintFactory.cs
@@ -312,7 +312,10 @@ namespace AGXUnity.BrickUnity.Factories
                                           bool overwriteIfDefault)
     {
       if (overwriteIfDefault || !stiffness.GetValueIsDefault(dof))
+      {
         constraint.SetCompliance(1f / stiffness.GetValue(dof), dof);
+        constraint.SetDamping(constraint.GetDamping(dof) / stiffness.GetValue(dof), dof);
+      }
     }
 
     /// <summary>
@@ -328,7 +331,10 @@ namespace AGXUnity.BrickUnity.Factories
                                           bool overwriteIfDefault)
     {
       if (overwriteIfDefault || !stiffness.GetValueIsDefault(dof))
+      {
         constraint.SetCompliance(1f / stiffness.GetValue(dof), dof);
+        constraint.SetDamping(constraint.GetDamping(dof) / stiffness.GetValue(dof), dof);
+      }
     }
 
     /// <summary>

--- a/AGXUnity/Constraint.cs
+++ b/AGXUnity/Constraint.cs
@@ -405,6 +405,35 @@ namespace AGXUnity
     }
 
     /// <summary>
+    /// Get a value from the ElementaryConstraintRowData instance of this constraint's
+    /// ordinary elementary constraints. This can be e.g. Compliance, Damping or ForceRange.
+    /// </summary>
+    /// <typeparam name="TOUT">The type of the outputed data.</typeparam>
+    /// <typeparam name="TDOF">Either RotationalDof or TranslationalDof</typeparam>
+    /// <param name="callback">Callback to fetch a value from a row data instance.</param>
+    /// <param name="dof">Enum value X, Y, or Z. If the enum value All is used, an exception will be thrown.</param>
+    /// <returns>The data to be fetched from the constraint.</returns>
+    private TOUT GetRowData<TOUT, TDOF>(Func<ElementaryConstraintRowData, TOUT> callback, TDOF dof)
+    {
+      if (System.Convert.ToInt32(dof) > 2)
+      {
+        throw new AGXUnity.Exception("Choose a degree of freedom for the row data. Cannot get row data for All.");
+      }
+
+      var rowParser = ConstraintUtils.ConstraintRowParser.Create(this);
+      var rows = typeof(TDOF) == typeof(TranslationalDof) ?
+                   rowParser.TranslationalRows :
+                   rowParser.RotationalRows;
+
+      var data = rows[System.Convert.ToInt32(dof)];
+      if (data != null)
+        return callback(data.RowData);
+      Debug.LogError($"Could not find row data for dof {dof}. Returning default.");
+      return default;
+    }
+
+
+    /// <summary>
     /// Set compliance to all ordinary degrees of freedom (not including controllers)
     /// of this constraint.
     /// </summary>
@@ -501,6 +530,66 @@ namespace AGXUnity
     public void SetForceRange( RangeReal forceRange, RotationalDof dof )
     {
       TraverseRowData( data => data.ForceRange = forceRange, dof );
+    }
+
+    /// <summary>
+    /// Get the compliance of a specified degree of freedom.
+    /// </summary>
+    /// <param name="dof">Specific rotational degree of freedom (X, Y, or Z). All is not valid.</param>
+    /// <returns>The compliance for the specified degree of freedom.</returns>
+    public float GetCompliance(RotationalDof dof)
+    {
+      return GetRowData(data => data.Compliance, dof);
+    }
+
+    /// <summary>
+    /// Get the compliance of a specified degree of freedom.
+    /// </summary>
+    /// <param name="dof">Specific translational degree of freedom (X, Y, or Z). All is not valid.</param>
+    /// <returns>The compliance for the specified degree of freedom.</returns>
+    public float GetCompliance(TranslationalDof dof)
+    {
+      return GetRowData(data => data.Compliance, dof);
+    }
+
+    /// <summary>
+    /// Get the damping of a specified degree of freedom.
+    /// </summary>
+    /// <param name="dof">Specific rotational degree of freedom (X, Y, or Z). All is not valid.</param>
+    /// <returns>The damping for the specified degree of freedom.</returns>
+    public float GetDamping(RotationalDof dof)
+    {
+      return GetRowData(data => data.Damping, dof);
+    }
+
+    /// <summary>
+    /// Get the damping of a specified degree of freedom.
+    /// </summary>
+    /// <param name="dof">Specific translational degree of freedom (X, Y, or Z). All is not valid.</param>
+    /// <returns>The damping for the specified degree of freedom.</returns>
+    public float GetDamping(TranslationalDof dof)
+    {
+      return GetRowData(data => data.Damping, dof);
+    }
+
+    /// <summary>
+    /// Get the force range of a specified degree of freedom.
+    /// </summary>
+    /// <param name="dof">Specific rotational degree of freedom (X, Y, or Z). All is not valid.</param>
+    /// <returns>The force range for the specified degree of freedom.</returns>
+    public RangeReal GetForceRange(RotationalDof dof)
+    {
+      return GetRowData(data => data.ForceRange, dof);
+    }
+
+    /// <summary>
+    /// Get the force range of a specified degree of freedom.
+    /// </summary>
+    /// <param name="dof">Specific translational degree of freedom (X, Y, or Z). All is not valid.</param>
+    /// <returns>The force range for the specified degree of freedom.</returns>
+    public RangeReal GetForceRange(TranslationalDof dof)
+    {
+      return GetRowData(data => data.ForceRange, dof);
     }
 
     /// <summary>


### PR DESCRIPTION
This MR allows not writing Brick values to AGXUnity constraints if the Brick values are default (not set manually by the user.

Other things:
- Adds methods to get compliance, damping and force range from AGXUnity constraints.
- Also adds some documentation to the ConstraintFactory methods.