### PR TITLE
Fixes to external handling

### DIFF
--- a/AGXUnity/BrickUnity/BrickObject.cs
+++ b/AGXUnity/BrickUnity/BrickObject.cs
@@ -39,6 +39,10 @@ namespace AGXUnity.BrickUnity
     {
       SetPath(b_object, go_parent);
       SetType(b_object);
+
+      // This object has probably been created by the Brick runtime and should not be synchronized
+      if (b_object._ModelValue is null)
+        synchronize = false;
     }
 
     public Brick.Path GetBrickPath()

--- a/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
+++ b/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
@@ -212,6 +212,8 @@ namespace AGXUnityEditor.BrickUnity
     // Add an AGXUnity shape to a GameObject from a Brick.Physics.Geometry object
     private void HandleGeometry(GameObject go, B_Geometry b_geometry)
     {
+      if (b_geometry.IsExternal)
+        return;
       var au_shape = go.AddShape(b_geometry);
       if (b_geometry.Material != null)
         if (shapeMaterials.ContainsKey(b_geometry.Material.Name))

--- a/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
+++ b/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
@@ -282,7 +282,7 @@ namespace AGXUnityEditor.BrickUnity
       go_constraint.name = b_connector._ModelValue.Name.Str;
       go_constraint.transform.SetParent(go_parent.transform, false);
       var c_brickObject = go_constraint.AddBrickObject(b_connector, go_parent);
-      c_brickObject.synchronize = synchronize;
+      c_brickObject.synchronize &= synchronize;
 
       var constraint = go_constraint.GetComponent<AGXUnity.Constraint>();
 
@@ -323,9 +323,8 @@ namespace AGXUnityEditor.BrickUnity
       var c_constraint = tf_constraint.gameObject.GetComponent<AGXUnity.Constraint>();
       c_constraint.gameObject.name = b_connector.GetValueNameOrModelPath();
       c_constraint.SetComplianceAndDamping(b_connector.MainInteraction, true);
-      var c_brickObject = c_constraint.gameObject.AddBrickObject(b_connector, go);
+      c_constraint.gameObject.AddBrickObject(b_connector, go);
       c_constraint.SetControllers(b_connector, true);
-      c_brickObject.synchronize = true;
     }
 
 

--- a/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
+++ b/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
@@ -13,7 +13,6 @@ using B_Connector = Brick.Physics.Mechanics.AttachmentPairConnector;
 using B_MultiConnector = Brick.Physics.Mechanics.MultiAttachmentConnector;
 using B_Geometry = Brick.Physics.Geometry;
 using B_Visual = Brick.Visual;
-using B_RbAttachment = Brick.Physics.Mechanics.RigidBodyAttachment;
 using System.Linq;
 using AGXUnityEditor.IO;
 


### PR DESCRIPTION
Fixes 2 issues with the external handling:

- Geometries shouldn't be added again if they were already added by the external
- Objects that don't have a representation in the Brick file should not be synchronized