### PR TITLE
Make brick component public in BrickRuntimeComponent

### DIFF
--- a/AGXUnity/BrickUnity/BrickRuntimeComponent.cs
+++ b/AGXUnity/BrickUnity/BrickRuntimeComponent.cs
@@ -21,6 +21,8 @@ namespace AGXUnity.BrickUnity
     protected B_Component m_component;
     private B_BrickSimulation m_brickSimulation;
 
+    public B_Component Component => m_component;
+
     public B_Agent GetBrickAgent(string agentName)
     {
       B_Agent agent = null;


### PR DESCRIPTION
Make it possible to access the brick component read from file in other places than just the BrickRuntimeComponent-script.