### PR TITLE
Remove extra rotation of gameobjects which messed up some scenes

### DIFF
--- a/AGXUnity/BrickUnity/BrickExtensions.cs
+++ b/AGXUnity/BrickUnity/BrickExtensions.cs
@@ -77,7 +77,7 @@ namespace AGXUnity.BrickUnity
     public static void SetLocalFromBrick(this Transform u_transform, Brick.Scene.Transform b_transform)
     {
       u_transform.localPosition = b_transform.Position.ToHandedVector3();
-      u_transform.localRotation = b_transform.Rotation.ToHandedQuaternion()*u_transform.localRotation;
+      u_transform.localRotation = b_transform.Rotation.ToHandedQuaternion();
     }
 
     public static BrickObject AddBrickObject(this GameObject go, Brick.Object b_object, GameObject go_parent = null)


### PR DESCRIPTION
Remove an extra rotation of gameobjects when creating them. Was originally interned for when cameras was created, to get the rotation of them correct, and it assumes there is never an rotation in the new gameobject to begin with, which seems to not be the case, so we remove this extra rotation.

The camera rotation has to be solved in some other way.
 