### PR TITLE
Make it possible to find moved data folder

### DIFF
--- a/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
+++ b/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
@@ -71,14 +71,15 @@ namespace AGXUnityEditor.BrickUnity
       var b_simulation = new Brick.AGXBrick.BrickSimulation();
       b_simulation.AddComponent(b_component);
 
-      // TODO: if source filepath is within the Assets directory so should we set the rootpath to that.
       RootPath = "Assets";
       Name = b_component._ModelValuePath.Name.Str;
+      // Search subdirectories in Assets to see if the folder already exists somewhere, in another folder.
+      // Will change RootPath name if a folder is found.
+      FindExistingFolder();
       GetOrCreateDataDirectory();
       // TODO: If the DataDirectory already exists. For all asset types load the existing assets into the appropriate dictionary.
       GetSavedAssets(contactMaterials, RestoredAssetsRoot.ContainingType.ContactMaterial);
       GetSavedAssets(frictionModels, RestoredAssetsRoot.ContainingType.FrictionModel);
-
 
       // Creates ShapeMaterials and ContactMaterials
       HandleMaterials(b_component);
@@ -504,6 +505,29 @@ namespace AGXUnityEditor.BrickUnity
       if (!AssetDatabase.IsValidFolder(DataDirectoryPath))
         AssetDatabase.CreateFolder(RootPath, Name + "_Data");
       return new DirectoryInfo(DataDirectoryPath);
+    }
+
+    // Will find if a data folder for the given Brick object already exists and set RootPath to be correct if that
+    // is the case
+    private string FindExistingFolder()
+    {
+      DirectoryInfo dirInfo = new DirectoryInfo(Application.dataPath);
+      var foundDirs = dirInfo.EnumerateDirectories("*" + Name + "_Data" + "*.*", SearchOption.AllDirectories).ToList();
+      if (foundDirs.Count >0)
+      {
+        var path = foundDirs.First().FullName;
+        char[] separators = { '\\', '/' };
+        var splitPath = path.Split(separators).ToList();
+        int index = splitPath.FindIndex(x => x=="Assets");
+        string assetsPath = "Assets";
+        for (int i=index+1; i < splitPath.Count; i++){
+          assetsPath += "/" + splitPath[i];
+        }
+        RootPath = assetsPath;
+        Debug.Log(assetsPath);
+        return path;
+      }
+      return null;
     }
 
     private void RefreshAssets()

--- a/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
+++ b/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
@@ -524,7 +524,6 @@ namespace AGXUnityEditor.BrickUnity
           assetsPath += "/" + splitPath[i];
         }
         RootPath = assetsPath;
-        Debug.Log(assetsPath);
         return path;
       }
       return null;

--- a/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
+++ b/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
@@ -512,16 +512,20 @@ namespace AGXUnityEditor.BrickUnity
     private string FindExistingFolder()
     {
       DirectoryInfo dirInfo = new DirectoryInfo(Application.dataPath);
-      var foundDirs = dirInfo.EnumerateDirectories("*" + Name + "_Data" + "*.*", SearchOption.AllDirectories).ToList();
+      var foundDirs = dirInfo.EnumerateDirectories(Name + "_Data", SearchOption.AllDirectories).ToList();
       if (foundDirs.Count >0)
       {
         var path = foundDirs.First().FullName;
         char[] separators = { '\\', '/' };
         var splitPath = path.Split(separators).ToList();
-        int index = splitPath.FindIndex(x => x=="Assets");
+        int startIndex = splitPath.FindIndex(x => x=="Assets") + 1;
         string assetsPath = "Assets";
-        for (int i=index+1; i < splitPath.Count; i++){
+        for (int i=startIndex; i < splitPath.Count-1; i++){
           assetsPath += "/" + splitPath[i];
+        }
+        if (foundDirs.Count > 1)
+        {
+          Debug.LogWarning("Found multiple data directories with same name for " + Name + ". Using path: " + path);
         }
         RootPath = assetsPath;
         return path;

--- a/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
+++ b/Editor/AGXUnityEditor/BrickUnity/BrickPrefabImporter.cs
@@ -73,9 +73,9 @@ namespace AGXUnityEditor.BrickUnity
 
       RootPath = "Assets";
       Name = b_component._ModelValuePath.Name.Str;
-      // Search subdirectories in Assets to see if the folder already exists somewhere, in another folder.
-      // Will change RootPath name if a folder is found.
-      FindExistingFolder();
+      // Search subdirectories in Assets to see if the data directory already exists somewhere.
+      // Will change RootPath name if a directory is found.
+      FindExistingDataDirectory();
       GetOrCreateDataDirectory();
       // TODO: If the DataDirectory already exists. For all asset types load the existing assets into the appropriate dictionary.
       GetSavedAssets(contactMaterials, RestoredAssetsRoot.ContainingType.ContactMaterial);
@@ -507,25 +507,26 @@ namespace AGXUnityEditor.BrickUnity
       return new DirectoryInfo(DataDirectoryPath);
     }
 
-    // Will find if a data folder for the given Brick object already exists and set RootPath to be correct if that
+    // Will find if a data directory for the given Brick object already exists and set RootPath to be correct if that
     // is the case
-    private string FindExistingFolder()
+    private string FindExistingDataDirectory()
     {
       DirectoryInfo dirInfo = new DirectoryInfo(Application.dataPath);
       var foundDirs = dirInfo.EnumerateDirectories(Name + "_Data", SearchOption.AllDirectories).ToList();
       if (foundDirs.Count >0)
       {
         var path = foundDirs.First().FullName;
+        if (foundDirs.Count > 1)
+        {
+          Debug.LogWarning("Found multiple data directories with same name for " + Name + ". Using path: " + path);
+        }
+
         char[] separators = { '\\', '/' };
         var splitPath = path.Split(separators).ToList();
         int startIndex = splitPath.FindIndex(x => x=="Assets") + 1;
         string assetsPath = "Assets";
         for (int i=startIndex; i < splitPath.Count-1; i++){
           assetsPath += "/" + splitPath[i];
-        }
-        if (foundDirs.Count > 1)
-        {
-          Debug.LogWarning("Found multiple data directories with same name for " + Name + ". Using path: " + path);
         }
         RootPath = assetsPath;
         return path;


### PR DESCRIPTION
Earlier, the data folder was always created in the same spot, directly under Assets. And moving it and reloading the Brick model, would cause duplicates, which caused problems.

Now, we make sure it first searches all the folders in Assets for the data folder, before creating a new one, and use that one if it finds it instead. 